### PR TITLE
Fix race condition in show_week_data

### DIFF
--- a/controllers/tasks_commands.py
+++ b/controllers/tasks_commands.py
@@ -19,6 +19,7 @@ from data_access.subscribers_access import is_banned_user, is_registered_user, g
 import helpers
 import UI
 
+import io
 import datetime
 import client
 import matplotlib.pyplot as plt
@@ -227,9 +228,11 @@ class TasksCog(commands.Cog):
             width = bar.get_width()
             ax.text(width, bar.get_y() + bar.get_height() / 2, width, va='center')
         plt.tight_layout()
-        plt.savefig('week_progress.png')
+        image = io.BytesIO()
+        plt.savefig(image)
         plt.close()
-        file = discord.File('week_progress.png')
+        image.seek(0)
+        file = discord.File(image, filename='week_progress.png')
         await interaction.response.send_message(files=[file])
         
     


### PR DESCRIPTION
The command `/show_week_data` saves the chart as a file on disk, then reads this file and sends it to discord. This has several issues:
1. If multiple interactions are being executed concurrently, the file read in one interaction may be the one written by the other interaction. This is called a race condition, and in this case it may introduce a data leak between different guilds.
1. It keeps a useless file after the command has finished executing.
1. The file may fail to be written to the file system for unrelated reasons, for example: out of storage, lack of permission, read-only file system, etc.

This pull request fixes these issues by writing the file to memory instead.